### PR TITLE
add github actions to publish to npm and gh-pages

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,19 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn
+      - run: yarn build
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/storybook-gh-pages-deploy.yml
+++ b/.github/workflows/storybook-gh-pages-deploy.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        run: |
+          yarn
+          yarn build-storybook
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.7
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: .out # The folder the action should deploy.

--- a/.github/workflows/storybook-gh-pages-deploy.yml
+++ b/.github/workflows/storybook-gh-pages-deploy.yml
@@ -17,5 +17,7 @@ jobs:
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.7
         with:
+          clean: true
           branch: gh-pages # The branch the action should deploy to.
           folder: .out # The folder the action should deploy.
+          ssh-key: ${{ secrets.DEPLOY_KEY }} # using ssh key as token does not have permission to build gh-pages - https://github.com/JamesIves/github-pages-deploy-action/tree/dev#using-an-ssh-deploy-key-

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 lib/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 lib/
 .idea
+.out

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+This is a template to develop and release a react component. This also includes github action for releasing the npm module.
+
+## Step to release the npm module
+1. Create a new account in npm.
+   https://www.npmjs.com/signup
+2. Create a new access token and select publish as a type
+   https://www.npmjs.com/settings/upnotes/tokens
+3. Add secret to your repo or organization as NPM_TOKEN
+   https://github.com/organizations/upnotes-io/settings/secrets/actions/new
+4. Create a new tag and use that tag to create the release. Creating a new release will trigger the [workflow](https://github.com/upnotes-io/react-component-template/blob/main/.github/workflows/npm-publish.yml). 
+

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ This is a template to develop and release a react component. This also includes 
    https://github.com/organizations/upnotes-io/settings/secrets/actions/new
 4. Create a new tag and use that tag to create the release. Creating a new release will trigger the [workflow](https://github.com/upnotes-io/react-component-template/blob/main/.github/workflows/npm-publish.yml). 
 
+### Publishing to github pages:
+Adding deploy keys to your repo:
+1. https://github.com/JamesIves/github-pages-deploy-action/tree/dev#using-an-ssh-deploy-key-
+2. https://docs.github.com/en/developers/overview/managing-deploy-keys#setup-2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 This is a template to develop and release a react component. This also includes github action for releasing the npm module.
 
+Storybook 
+https://upnotes-io.github.io/my-awesome-component-library/
+
+![image](https://user-images.githubusercontent.com/5221843/147892813-146197d8-9385-4ddf-a928-5eb7e55a051a.png)
+
+
+
 ## Step to release the npm module
 1. Create a new account in npm.
    https://www.npmjs.com/signup

--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ https://upnotes-io.github.io/my-awesome-component-library/
 Adding deploy keys to your repo:
 1. https://github.com/JamesIves/github-pages-deploy-action/tree/dev#using-an-ssh-deploy-key-
 2. https://docs.github.com/en/developers/overview/managing-deploy-keys#setup-2
+
+### Used by 
+1. https://github.com/upnotes-io/react-todo - A generic todo list component for react. This is being used in an electron based app: https://upnotes.io
+
+Please create a PR if you are using this template in your open source project.

--- a/components/Button/Button.d.ts
+++ b/components/Button/Button.d.ts
@@ -1,0 +1,29 @@
+import React from "react";
+import "./button.css";
+export interface ButtonProps {
+    /**
+     * Is this the principal call to action on the page?
+     */
+    primary?: boolean;
+    /**
+     * What background color to use
+     */
+    backgroundColor?: string;
+    /**
+     * How large should the button be?
+     */
+    size?: "small" | "medium" | "large";
+    /**
+     * Button contents
+     */
+    label: string;
+    /**
+     * Optional click handler
+     */
+    onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}
+/**
+ * Primary UI component for user interaction
+ */
+declare const Button: ({ primary, backgroundColor, size, onClick, label, }: ButtonProps) => JSX.Element;
+export default Button;

--- a/components/Button/Button.stories.d.ts
+++ b/components/Button/Button.stories.d.ts
@@ -1,0 +1,7 @@
+import { Meta } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
+import { ButtonProps } from "./Button";
+declare const _default: Meta<import("@storybook/react").Args>;
+export default _default;
+export declare const Primary: Story<ButtonProps>;
+export declare const Secondary: Story<ButtonProps>;

--- a/components/Button/index.d.ts
+++ b/components/Button/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from "./Button";

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+import Button from "./components/Button";
+export { Button };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upnotes-react-component-template",
-  "version": "0.1.15",
+  "version": "0.1.17",
   "description": "A storybook 6 with TypeScript demo",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",
@@ -8,11 +8,14 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
+    "build-storybook": "build-storybook -c .storybook -o .out",
     "build": "rollup -c",
-    "prepublishOnly": "yarn build",
-    "build-storybook": "build-storybook -c .storybook -o .out"
+    "prepublishOnly": "yarn build"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "np": {
     "publish": false,
     "tests": false
@@ -46,6 +49,5 @@
   "peerDependencies": {
     "react": "^16.13.0",
     "react-dom": "^16.13.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "my-awesome-component-library",
-  "version": "1.0.3",
-  "description": "A stroybook 6 with TypeScript demo",
+  "name": "upnotes-react-component-template",
+  "version": "0.1.13",
+  "description": "A storybook 6 with TypeScript demo",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",
@@ -10,7 +10,8 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "build": "rollup -c",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "build-storybook": "build-storybook -c .storybook -o .out"
   },
   "np": {
     "publish": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upnotes-react-component-template",
-  "version": "0.1.13",
+  "version": "0.1.15",
   "description": "A storybook 6 with TypeScript demo",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "upnotes-react-component-template",
-  "version": "0.1.17",
+  "name": "my-awesome-component-library",
+  "version": "1.1.0",
   "description": "A storybook 6 with TypeScript demo",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ export default {
     peerDepsExternal(),
     resolve(),
     commonjs(),
-    typescript({ useTsconfigDeclarationDir: true }),
+    typescript({  tsconfig: './tsconfig.json',useTsconfigDeclarationDir: true , clean: true}),
     postcss({
         extensions: ['.css']
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,15 @@
 {
     "compilerOptions": {
       "target": "es5",
-      "outDir": "lib",
+      "rootDir": "./src",
+      "outDir": "./lib",
       "lib": [
         "dom",
         "dom.iterable",
         "esnext"
       ],
       "declaration": true,
-      "declarationDir": "lib",
+      "declarationDir": "./",
       "allowJs": true,
       "skipLibCheck": true,
       "esModuleInterop": true,


### PR DESCRIPTION
Hi @prateek3255 , thanks a lot for the template. I have improved it and added 
1. Github action to publish to npm with readme to setup the action.
2. Publishing storybook to gh-pages
3. Bug fixes

The modified template is being used in https://github.com/upnotes-io/react-todo